### PR TITLE
Refactor sourcing of suggestions

### DIFF
--- a/routing-lambda/src/test/scala/sg/beeline/RoutingLambdaSpec.scala
+++ b/routing-lambda/src/test/scala/sg/beeline/RoutingLambdaSpec.scala
@@ -21,7 +21,7 @@ class RoutingLambdaSpec extends FunSuite {
   val problem = new BasicRoutingProblem(
     List(),
     dataSource = BuiltIn,
-    settings = BeelineRecreateSettings.default)
+    settings = BeelineRecreateSettings.DEFAULT)
 
   ignore("Route encoder works with empty Activity classes") {
     import sg.beeline.ruinrecreate.BeelineSuggestRouteSerdes._

--- a/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
+++ b/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
@@ -1,12 +1,13 @@
 package sg.beeline.io
 
-import sg.beeline.problem.{BusStop, Suggestion}
+import sg.beeline.problem.Suggestion
+import sg.beeline.ruinrecreate.BeelineRecreateSettings
 import sg.beeline.util.{ExpiringCache, Projections}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-object Import {
+class SuggestionsSource {
   // Return the number of seconds since midnight
   def convertTime(timeString: String) =
     timeString.substring(0,2).toLong * 3600000 +
@@ -87,5 +88,12 @@ object Import {
       Await.result(db.run(suggestions), 60 seconds)
     }
   }
-  def getLiveRequests = liveRequestsCache.apply
+  def getLiveRequests: Seq[Suggestion] = liveRequestsCache.apply
+
+  def similarTo(s: Suggestion, settings: BeelineRecreateSettings): Seq[Suggestion] =
+    getLiveRequests.filter(settings.suggestionsFilter(s))
+}
+
+object SuggestionsSource {
+  val DEFAULT = new SuggestionsSource
 }

--- a/routing-web/src/main/scala/sg/beeline/web/RoutingApp.scala
+++ b/routing-web/src/main/scala/sg/beeline/web/RoutingApp.scala
@@ -1,6 +1,6 @@
 package sg.beeline.web
 
-import sg.beeline.io.{BuiltIn, Import}
+import sg.beeline.io.{BuiltIn, SuggestionsSource}
 import sg.beeline.ruinrecreate.AWSLambdaSuggestRouteServiceProxy
 import sg.beeline.util.Geo
 
@@ -19,7 +19,7 @@ object RoutingApp extends App {
   val bindingFuture = Http().bindAndHandle(
     new IntelligentRoutingService(
       BuiltIn,
-      Import.getLiveRequests,
+      SuggestionsSource.DEFAULT,
       AWSLambdaSuggestRouteServiceProxy).myRoute,
     "0.0.0.0",
     scala.util.Properties.envOrElse("PORT", "8080").toInt

--- a/routing/src/main/scala/sg/beeline/ruinrecreate/BeelineRecreate.scala
+++ b/routing/src/main/scala/sg/beeline/ruinrecreate/BeelineRecreate.scala
@@ -9,7 +9,7 @@ import scala.collection.immutable.HashMap
 import scala.util.Random
 
 class BeelineRecreate(routingProblem : RoutingProblem, requests: Traversable[Request])
-                     (implicit settings : BeelineRecreateSettings = BeelineRecreateSettings.default) extends Recreate {
+                     (implicit settings : BeelineRecreateSettings = BeelineRecreateSettings.DEFAULT) extends Recreate {
   type Insertion = (Double, Activity, Activity, (Activity, Activity), (Activity, Activity))
 
   var count: Int = 0

--- a/routing/src/main/scala/sg/beeline/ruinrecreate/BeelineRecreateSettings.scala
+++ b/routing/src/main/scala/sg/beeline/ruinrecreate/BeelineRecreateSettings.scala
@@ -37,5 +37,5 @@ case class BeelineRecreateSettings(maxDetourMinutes : Double = 15.0,
 }
 
 object BeelineRecreateSettings {
-  lazy val default = new BeelineRecreateSettings()
+  lazy val DEFAULT = new BeelineRecreateSettings()
 }

--- a/routing/src/test/scala/sg/beeline/BeelineSuggestRouteSpec.scala
+++ b/routing/src/test/scala/sg/beeline/BeelineSuggestRouteSpec.scala
@@ -78,7 +78,7 @@ class BeelineSuggestRouteSpec extends FunSuite {
 
   test ("All suggestions have an associated stop (albeit far)") {
     implicit val executionContext = ExecutionContext.fromExecutor(new ForkJoinPool(2))
-    val problem = new BasicRoutingProblem(List(), testDataSource, BeelineRecreateSettings.default)
+    val problem = new BasicRoutingProblem(List(), testDataSource, BeelineRecreateSettings.DEFAULT)
     val otherRequest = new BasicRequest(
       problem,
       Projections.toSVY(gridToLngLat(-2, -2)),

--- a/routing/src/test/scala/sg/beeline/RouteSpec.scala
+++ b/routing/src/test/scala/sg/beeline/RouteSpec.scala
@@ -35,7 +35,7 @@ class RouteSpec extends FlatSpec with Matchers {
     override def nearestBusStop(point: (Double, Double)): BusStop =
       busStops.minBy(b => squaredDistance(point, b.xy))
 
-    override def settings: BeelineRecreateSettings = BeelineRecreateSettings.default
+    override def settings: BeelineRecreateSettings = BeelineRecreateSettings.DEFAULT
   }
   val testDataSource = new DataSource {
     override def busStops: Seq[BusStop] = ZeroDistance.busStops

--- a/routing/src/test/scala/sg/beeline/RuinSpec.scala
+++ b/routing/src/test/scala/sg/beeline/RuinSpec.scala
@@ -37,7 +37,7 @@ class RuinSpec extends FlatSpec with Matchers {
       squaredDistance(a.xy, b.xy) / 11 / 60
   }
 
-  val problem = new BasicRoutingProblem(requests, dataSource = testDataSource, settings = BeelineRecreateSettings.default)
+  val problem = new BasicRoutingProblem(requests, dataSource = testDataSource, settings = BeelineRecreateSettings.DEFAULT)
 
   val (routes, validRequests, badRequests) = problem.initialize
 


### PR DESCRIPTION
* Rename Import -> SuggestionsSource, convert to class
* Let RouteActor take in a `(suggestion, settings) => Seq[Suggestion]`
  instead of a reference to the entire suggestions universe,
  so that it is no longer concerned with which suggestions to pick
  from the universe to generate a route, given a seed suggestion
* Move the filtering of suggestions universe to SuggestionsSource

TODO: Rework SuggestionsSource#similarTo to query the database instead
of filtering the universe