### PR TITLE
Source suggestions cluster direct from DB

### DIFF
--- a/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
+++ b/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
@@ -1,13 +1,43 @@
 package sg.beeline.io
 
+import java.sql.Timestamp
+
 import sg.beeline.problem.Suggestion
 import sg.beeline.ruinrecreate.BeelineRecreateSettings
 import sg.beeline.util.{ExpiringCache, Projections}
+import slick.jdbc.SQLActionBuilder
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import scala.util.Properties
+import slick.jdbc.PostgresProfile.api._
+
 
 class SuggestionsSource {
+  private lazy val db = {
+    val (username, password, host, database) = {
+      val URI = new java.net.URI(
+        Properties.propOrElse(
+          "database.url",
+          Properties.envOrElse("DATABASE_URL", "(No database URL provided)")
+        )
+      )
+      val userPass = URI.getUserInfo.split(":")
+
+      (
+        userPass(0),
+        userPass(1),
+        URI.getHost,
+        URI.getPath
+      )
+    }
+    Database.forURL(
+      s"jdbc:postgresql://${host}${database}?user=${username}&" +
+        s"password=${password}&ssl=true&" +
+        s"sslfactory=org.postgresql.ssl.NonValidatingFactory",
+      driver = "org.postgresql.Driver"
+    )
+  }
   // Return the number of seconds since midnight
   def convertTime(timeString: String) =
     timeString.substring(0,2).toLong * 3600000 +
@@ -23,75 +53,92 @@ class SuggestionsSource {
     t
   }
 
+  private def suggestionsFrom(query: SQLActionBuilder)(implicit executionContext: ExecutionContext) = {
+    query
+      .as[(Long, Int, Double, Double, Double, Double, Option[Int], Option[String], Long, Int, Timestamp)]
+      .map[Seq[Suggestion]]({ results =>
+      genericWrapArray(results.view.map({
+        case (travelTime, id, boardLng, boardLat, alightLng, alightLat, userId, email, time, daysOfWeek, createdAt) =>
+          Suggestion(
+            id = id,
+            start = Projections.toSVY((boardLng, boardLat)),
+            end = Projections.toSVY((alightLng, alightLat)),
+            time = time,
+            createdAt = createdAt.getTime,
+            userId = userId,
+            daysOfWeek = daysOfWeek,
+            email = email
+          )
+      }).toArray)
+    })
+  }
 
   private val liveRequestsCache : ExpiringCache[Seq[Suggestion]] = ExpiringCache(10 minutes) {
     timeFn("Refreshing suggestions cache") {
-      import slick.jdbc.PostgresProfile.api._
-
       import scala.concurrent.ExecutionContext.Implicits.global
       import scala.concurrent.duration._
 
-      val (scheme, username, password, host, database) = {
-        val URI = new java.net.URI(scala.util.Properties.envOrElse("DATABASE_URL", "(No database URL provided"))
-        val userPass = URI.getUserInfo.split(":")
+      val query = sql"""
+        SELECT
+          DISTINCT ON (board, alight, time, email)
+          "travelTime",
+          id,
+          ST_X(board) AS board_lng,
+          ST_Y(board) AS board_lat,
+          ST_X(alight) AS alight_lng,
+          ST_Y(alight) AS alight_lat,
+          "userId",
+          email,
+          time,
+          "daysMask",
+          "createdAt"
+        FROM suggestions
+        ORDER BY board, alight, time, email
+      """
 
-        (
-          URI.getScheme,
-          userPass(0),
-          userPass(1),
-          URI.getHost,
-          URI.getPath
-        )
-      }
-
-      val db = Database.forURL(
-        s"jdbc:postgresql://${host}${database}?user=${username}&" +
-          s"password=${password}&ssl=true&" +
-          s"sslfactory=org.postgresql.ssl.NonValidatingFactory",
-        driver = "org.postgresql.Driver"
-      )
-      val session = db.createSession()
-      val suggestions = sql"""
-         SELECT
-             DISTINCT ON (board, alight, time, email)
-             "travelTime",
-             id,
-             ST_X(board) AS board_lng,
-             ST_Y(board) AS board_lat,
-             ST_X(alight) AS alight_lng,
-             ST_Y(alight) AS alight_lat,
-             "userId",
-             email,
-             time,
-             "daysMask",
-             "createdAt"
-         FROM suggestions
-         ORDER BY board, alight, time, email
-       """
-        .as[(Long, Int, Double, Double, Double, Double, Option[Int], Option[String], Long, Int, java.sql.Timestamp)]
-        .map[Seq[Suggestion]]({ results =>
-        genericWrapArray(results.view.map({
-          case (travelTime, id, boardLng, boardLat, alightLng, alightLat, userId, email, time, daysOfWeek, createdAt) =>
-            Suggestion(
-              id = id,
-              start = Projections.toSVY((boardLng, boardLat)),
-              end = Projections.toSVY((alightLng, alightLat)),
-              time = time,
-              createdAt = createdAt.getTime,
-              userId = userId,
-              daysOfWeek = daysOfWeek,
-              email = email
-            )
-        }).toArray)
-      })
-
-      Await.result(db.run(suggestions), 60 seconds)
+      Await.result(db.run(suggestionsFrom(query)), 60 seconds)
     }
   }
+
   def getLiveRequests: Seq[Suggestion] = liveRequestsCache.apply
 
-  def similarTo(s: Suggestion, settings: BeelineRecreateSettings): Seq[Suggestion] =
-    getLiveRequests.filter(settings.suggestionsFilter(s))
+  def similarTo(s: Suggestion, settings: BeelineRecreateSettings): Seq[Suggestion] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    import scala.concurrent.duration._
+
+    val query = sql"""
+      SELECT
+        DISTINCT ON (board, alight, time, email)
+        "travelTime",
+        id,
+        ST_X(board) AS board_lng,
+        ST_Y(board) AS board_lat,
+        ST_X(alight) AS alight_lng,
+        ST_Y(alight) AS alight_lat,
+        "userId",
+        email,
+        time,
+        "daysMask",
+        "createdAt"
+      FROM suggestions
+      WHERE
+        (${settings.includeAnonymous} OR "userId" is not null OR email is not null)
+        AND extract(epoch from "createdAt") * 1000 > ${settings.createdSince}
+        AND ABS(time - ${s.time}) <= ${settings.timeAllowance}
+        AND (${!settings.matchDaysOfWeek} OR ("daysMask" & ${s.daysOfWeek}) > 0)
+        AND ST_Distance(
+          ST_Transform(ST_SetSRID(board, 4326), 3414),
+          ST_SetSRID(ST_MakePoint(${s.start._1}, ${s.start._2}), 3414)
+        ) < ${settings.startClusterRadius}
+        AND ST_Distance(
+          ST_Transform(ST_SetSRID(alight, 4326), 3414),
+          ST_SetSRID(ST_MakePoint(${s.end._1}, ${s.end._2}), 3414)
+        ) < ${settings.endClusterRadius}
+      ORDER BY board, alight, time, email
+    """
+
+    Await.result(db.run(suggestionsFrom(query)), 60 seconds)
+  }
 }
 
 object SuggestionsSource {

--- a/routing-web/src/main/scala/sg/beeline/jobs/RouteActor.scala
+++ b/routing-web/src/main/scala/sg/beeline/jobs/RouteActor.scala
@@ -1,10 +1,9 @@
 package sg.beeline.jobs
 
-import java.sql.Timestamp
 import java.util.concurrent.ForkJoinPool
 
 import akka.actor.Actor
-import sg.beeline.io.{BuiltIn, DataSource}
+import sg.beeline.io.DataSource
 import sg.beeline.problem._
 import sg.beeline.ruinrecreate._
 import sg.beeline.util.Projections

--- a/routing/src/main/scala/sg/beeline/ruinrecreate/BeelineRecreateSettings.scala
+++ b/routing/src/main/scala/sg/beeline/ruinrecreate/BeelineRecreateSettings.scala
@@ -1,40 +1,24 @@
 package sg.beeline.ruinrecreate
 
-import sg.beeline.problem.Suggestion
-import sg.beeline.util.squaredDistance
+case class BeelineRecreateSettings(
+  maxDetourMinutes : Double = 15.0,
+  startClusterRadius : Int = 4000,
+  startWalkingDistance : Int = 400,
+  endClusterRadius : Int = 4000,
+  endWalkingDistance : Int = 400,
 
-case class BeelineRecreateSettings(maxDetourMinutes : Double = 15.0,
-                                   startClusterRadius : Int = 4000,
-                                   startWalkingDistance : Int = 400,
-                                   endClusterRadius : Int = 4000,
-                                   endWalkingDistance : Int = 400,
+  timeAllowance: Long = 1800 * 1000L, // Half an hour
+  similarityLimit: Float = 0.3f,
+  imputedDwellTime: Long = 60000,
+  suboptimalStopChoiceAllowance: Long = 60000,
 
-                                   timeAllowance: Long = 1800 * 1000L, // Half an hour
-                                   similarityLimit: Float = 0.3f,
-                                   imputedDwellTime: Long = 60000,
-                                   suboptimalStopChoiceAllowance: Long = 60000,
+  includeAnonymous: Boolean = true,
+  matchDaysOfWeek: Boolean = true,
+  createdSince: Long = 0L,
+  minRequests: Int = 15,
 
-                                   includeAnonymous: Boolean = true,
-                                   matchDaysOfWeek: Boolean = true,
-                                   createdSince: Long = 0L,
-                                   minRequests: Int = 15,
-
-                                   dataSource : String = "suggestions"
-                             ) {
-
-  def suggestionsFilter(reference: Suggestion): Suggestion => Boolean = { s: Suggestion =>
-    // Determine whether or not to allow anonymous suggestions
-    (includeAnonymous || s.userId.nonEmpty || s.email.nonEmpty) &&
-      // Min created time (to ignore the really old requests)
-      s.createdAt > createdSince &&
-      // Ensure arrival time is plus/minus some value
-      (s.time - reference.time).abs <= timeAllowance &&
-      // Ensure that the daysOfWeek mask overlaps to some extent
-      (!matchDaysOfWeek || (s.daysOfWeek & reference.daysOfWeek) != 0) &&
-      squaredDistance(reference.start, s.start) < startClusterRadius * startClusterRadius &&
-      squaredDistance(reference.end, s.end) < endClusterRadius * endClusterRadius
-  }
-}
+  dataSource : String = "suggestions"
+)
 
 object BeelineRecreateSettings {
   lazy val DEFAULT = new BeelineRecreateSettings()


### PR DESCRIPTION
* Allow SuggestionsSource to use system property and env var for db url
* Have `db` and `suggestionsFrom` as class-level fields
  * `suggestionsFrom` takes a slick SQL string and adds obj marshalling
* Re-impl `similarTo` to find similar suggestions from db, not in-mem