### PR TITLE
Refactor route generation trigger, alias path, add trigger time check

### DIFF
--- a/routing-web/src/main/scala/sg/beeline/web/Web.scala
+++ b/routing-web/src/main/scala/sg/beeline/web/Web.scala
@@ -1,5 +1,6 @@
 package sg.beeline.web
 
+import java.sql.Timestamp
 import java.time._
 import java.util.{NoSuchElementException, UUID}
 
@@ -7,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import akka.http.scaladsl.server.Directives.{path, post}
 import akka.http.scaladsl.server.{Directives, ExceptionHandler}
 import sg.beeline.io.{DataSource, SuggestionsSource}
 import sg.beeline.jobs.{JobQueue, RouteActor}
@@ -80,6 +82,8 @@ class IntelligentRoutingService(dataSource: DataSource,
   }), "intelligent-routing")
   val jobQueue = new JobQueue[SuggestRequest, Try[List[Route2]]](
     routingActor, 10 minutes,5 minutes, actorSystem = Some(system))
+
+  val e2eSuggestion = new E2ESuggestion(routingActor)
 
   val myRoute = cors() {
     path("bus_stops") {
@@ -232,7 +236,16 @@ class IntelligentRoutingService(dataSource: DataSource,
         }
       }
     } ~
-    new E2ESuggestion(routingActor).e2eRoutes
+    path("suggestions" / IntNumber / "update") { suggestionId =>
+      post {
+        e2eSuggestion.triggerRouteGeneration(suggestionId)
+      }
+    } ~
+    path("suggestions" / IntNumber / "trigger_route_generation") { suggestionId =>
+      post {
+        e2eSuggestion.triggerRouteGeneration(suggestionId)
+      }
+    }
   }
 
 }


### PR DESCRIPTION
* Move route declaration portion in E2ESuggestion into Web to allow
  the bulk of logic to be re-used in an aliased path

* Take the opportunity to timestamp when a route is triggered in the
  suggestion itself. This is originally done by beeline-server, but
  is being reworked so that route generation requests will not have
  to be brokered through beeline-server and can be handled directly
  by beeline-routing

* Ensure that no suggestion triggers routes more frequently than
  once every 20s