### PR TITLE
E2ESuggestion refactoring

### DIFF
--- a/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
+++ b/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
@@ -7,7 +7,7 @@ import sg.beeline.ruinrecreate.BeelineRecreateSettings
 import sg.beeline.util.{ExpiringCache, Projections}
 import slick.jdbc.SQLActionBuilder
 
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.Properties
 import slick.jdbc.PostgresProfile.api._
@@ -164,6 +164,16 @@ class SuggestionsSource {
     """
 
     Await.result(db.run(suggestionsFrom(query)), 60 seconds).headOption
+  }
+
+  def markTriggerTimestamp(suggestionId: Int): Unit = {
+    val statement = sqlu"""
+      UPDATE suggestions
+      SET "lastTriggerTime" = NOW()
+      WHERE id = $suggestionId
+    """
+
+    Await.result(db.run(statement), 60 seconds)
   }
 }
 

--- a/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
+++ b/routing-web/src/main/scala/sg/beeline/io/SuggestionsSource.scala
@@ -55,10 +55,10 @@ class SuggestionsSource {
 
   private def suggestionsFrom(query: SQLActionBuilder)(implicit executionContext: ExecutionContext) = {
     query
-      .as[(Long, Int, Double, Double, Double, Double, Option[Int], Option[String], Long, Int, Timestamp)]
+      .as[(Long, Int, Double, Double, Double, Double, Option[Int], Option[String], Long, Int, Timestamp, Option[Timestamp])]
       .map[Seq[Suggestion]]({ results =>
       genericWrapArray(results.view.map({
-        case (travelTime, id, boardLng, boardLat, alightLng, alightLat, userId, email, time, daysOfWeek, createdAt) =>
+        case (travelTime, id, boardLng, boardLat, alightLng, alightLat, userId, email, time, daysOfWeek, createdAt, lastTriggerTime) =>
           Suggestion(
             id = id,
             start = Projections.toSVY((boardLng, boardLat)),
@@ -67,7 +67,8 @@ class SuggestionsSource {
             createdAt = createdAt.getTime,
             userId = userId,
             daysOfWeek = daysOfWeek,
-            email = email
+            email = email,
+            lastTriggerMillis = lastTriggerTime.map(_.getTime)
           )
       }).toArray)
     })
@@ -76,7 +77,6 @@ class SuggestionsSource {
   private val liveRequestsCache : ExpiringCache[Seq[Suggestion]] = ExpiringCache(10 minutes) {
     timeFn("Refreshing suggestions cache") {
       import scala.concurrent.ExecutionContext.Implicits.global
-      import scala.concurrent.duration._
 
       val query = sql"""
         SELECT
@@ -91,7 +91,8 @@ class SuggestionsSource {
           email,
           time,
           "daysMask",
-          "createdAt"
+          "createdAt",
+          "lastTriggerTime"
         FROM suggestions
         ORDER BY board, alight, time, email
       """
@@ -104,7 +105,6 @@ class SuggestionsSource {
 
   def similarTo(s: Suggestion, settings: BeelineRecreateSettings): Seq[Suggestion] = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    import scala.concurrent.duration._
 
     val query = sql"""
       SELECT
@@ -119,7 +119,8 @@ class SuggestionsSource {
         email,
         time,
         "daysMask",
-        "createdAt"
+        "createdAt",
+        "lastTriggerTime"
       FROM suggestions
       WHERE
         (${settings.includeAnonymous} OR "userId" is not null OR email is not null)
@@ -138,6 +139,31 @@ class SuggestionsSource {
     """
 
     Await.result(db.run(suggestionsFrom(query)), 60 seconds)
+  }
+
+  def byId(id: Int): Option[Suggestion] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val query = sql"""
+      SELECT
+        DISTINCT ON (board, alight, time, email)
+        "travelTime",
+        id,
+        ST_X(board) AS board_lng,
+        ST_Y(board) AS board_lat,
+        ST_X(alight) AS alight_lng,
+        ST_Y(alight) AS alight_lat,
+        "userId",
+        email,
+        time,
+        "daysMask",
+        "createdAt",
+        "lastTriggerTime"
+      FROM suggestions
+      WHERE
+        id = $id
+    """
+
+    Await.result(db.run(suggestionsFrom(query)), 60 seconds).headOption
   }
 }
 

--- a/routing-web/src/main/scala/sg/beeline/web/Web.scala
+++ b/routing-web/src/main/scala/sg/beeline/web/Web.scala
@@ -1,5 +1,6 @@
 package sg.beeline.web
 
+import java.sql.Timestamp
 import java.time._
 import java.util.{NoSuchElementException, UUID}
 
@@ -7,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import akka.http.scaladsl.server.Directives.{path, post}
 import akka.http.scaladsl.server.{Directives, ExceptionHandler}
 import sg.beeline.io.{DataSource, SuggestionsSource}
 import sg.beeline.jobs.{JobQueue, RouteActor}
@@ -80,6 +82,8 @@ class IntelligentRoutingService(dataSource: DataSource,
   }), "intelligent-routing")
   val jobQueue = new JobQueue[SuggestRequest, Try[List[Route2]]](
     routingActor, 10 minutes,5 minutes, actorSystem = Some(system))
+
+  val e2eSuggestion = new E2ESuggestion(routingActor)
 
   val myRoute = cors() {
     path("bus_stops") {
@@ -232,7 +236,16 @@ class IntelligentRoutingService(dataSource: DataSource,
         }
       }
     } ~
-    new E2ESuggestion(routingActor).e2eRoutes
+    path("suggestions" / IntNumber / "update") { suggestionId =>
+      post {
+        e2eSuggestion.triggerRouteGeneration(suggestionId)
+      }
+    } ~
+    path("suggestions" / IntNumber / "trigger_route_generation") { suggestionId =>
+      post {
+        e2eSuggestion.triggerRouteGeneration(suggestionId)
+      }
+    }
   }
 
 }

--- a/routing-web/src/main/scala/sg/beeline/web/Web.scala
+++ b/routing-web/src/main/scala/sg/beeline/web/Web.scala
@@ -83,7 +83,7 @@ class IntelligentRoutingService(dataSource: DataSource,
   val jobQueue = new JobQueue[SuggestRequest, Try[List[Route2]]](
     routingActor, 10 minutes,5 minutes, actorSystem = Some(system))
 
-  val e2eSuggestion = new E2ESuggestion(routingActor)
+  val e2eSuggestion = new E2ESuggestion(routingActor, suggestionsSource)
 
   val myRoute = cors() {
     path("bus_stops") {

--- a/routing/src/main/scala/sg/beeline/problem/Problem.scala
+++ b/routing/src/main/scala/sg/beeline/problem/Problem.scala
@@ -1,7 +1,5 @@
 package sg.beeline.problem
 
-import java.sql.Timestamp
-
 import sg.beeline.ruinrecreate.BeelineRecreateSettings
 import sg.beeline.util.Point
 import sg.beeline.util.Projections._
@@ -30,7 +28,7 @@ case class BusStop(
 
 case class Suggestion(id: Int, start: Point, end: Point, time: Double,
                       weight : Int = 1, createdAt: Long, userId: Option[Int],
-                      email: Option[String], daysOfWeek: Int) {
+                      email: Option[String], daysOfWeek: Int, lastTriggerMillis: Option[Long] = None) {
   lazy val startLngLat = toWGS(start)
   lazy val endLngLat = toWGS(end)
 


### PR DESCRIPTION
Refactor route generation trigger, alias path, add trigger time checks

* Move route declaration portion in E2ESuggestion into Web to allow
the bulk of logic to be re-used in an aliased path
* Take the opportunity to timestamp when a route is triggered in the
suggestion itself
* Ensure that no suggestion triggers routes more frequently than
once every 20s

Source suggestions directly from db 
* Add `lastTriggerMillis` as a field in Suggestion, set to the last
  time a route was generated from a request
* Inject SuggestionsSource into E2ESuggestion
* Rework `verifySuggestionId` into `makeSuggestRequest`, which
  will look up the suggestion from the db instead of beeline-server